### PR TITLE
Create consistent layout for OBS Overlay ingest

### DIFF
--- a/website/css/now-racing-obs.css
+++ b/website/css/now-racing-obs.css
@@ -1,0 +1,207 @@
+
+.flying {
+    position: fixed;
+    background-color: red;
+    left: -5em;
+    top: -5em;
+    width: 3em;
+    text-align: center;
+
+    padding: 13px;
+    display: table;
+}
+
+.flying span {
+    display: table-cell;
+    vertical-align: middle;
+}
+
+html, body, table { width: 100%; height: 100%; margin: 0; padding: 0; }
+
+/* To avoid scrollbars: */
+body { overflow: hidden; }
+
+table {
+  border-collapse: collapse;
+}
+
+td {
+    border: 14px solid black;
+    text-align: center;
+}
+
+/* Added for OBS consistent sizes.
+This may be overkill since it's also set in the 
+style parameters in the kiosk file */
+.photo {
+  width: 1px;
+}
+
+.lane {
+  width: 22px;
+}
+
+.carnumber {
+  width: 80px;
+}
+
+td.time td.speed td.place {
+  width: 80px;
+}
+/* end OBS edit */
+
+
+td.photo {
+    border-right-width: 0px;
+}
+td.name {
+    border-left-width: 0px;
+}
+
+/* OBS edit*/
+.name {
+  width:35%;
+}
+/* end OBS edit */
+
+
+td p {
+    /* TODO Chrome sets these to 1em for p by default?
+        Mozilla equivalents needed?  Others? */
+    -webkit-margin-before: 0px;
+    -webkit-margin-after: 0px;
+    margin-top: auto;
+    margin-bottom: auto;
+}
+
+th {
+    font-size: 32px;
+    /* Without fixing this value, WebKit (at least) calculates strangely large
+       initial heights, and then takes a few rounds to come to equilibrium.
+       41px = line height (1.3) for 32px font size.
+       $("#table-headers th").height() reports 48, the difference being
+       half the border width: */
+    height: 41px;
+}
+
+th .aside {
+    font-size: 24px;
+}
+
+#speed-div {
+    overflow-y: hidden;
+    /* Once again, lineheight for tr th, namely, 1.3 x 32px. */
+    max-height: 41px;
+}
+
+table, td {
+    /* This is just a placeholder value; the real font size gets set dynamically.
+       See js/now-racing-adjust-fonts.js */
+    font-size: 85px;
+}
+
+td {
+    vertical-align: middle;
+    /* ondeck.css:10 sets a 13px padding which makes more difference than you'd think. */
+    padding: 0px;
+}
+/* Not floating the img leaves some extra whitespace below the photo,
+   for reasons I don't understand (empty anonymous block box?). */
+td.photo img {
+    float: left;
+}
+
+td.test-only {
+  color: #fffd38;
+  background-color: #888;
+  font-size: 50px;
+  font-weight: bold;
+  text-align: center;
+}
+td.test-only img {
+  max-width: 50%;
+}
+
+@media screen and (max-width: 800px),
+       screen and (max-height: 500px) {
+  td {
+    border: 7px solid black;
+  }
+  th {
+    font-size: 20px;
+    height: 30px;
+  }
+}
+
+@media screen and (max-width: 600px),
+       screen and (max-height: 350px) {
+  td {
+    border: 5px solid black;
+  }
+  th {
+    font-size: 16px;
+    height: 22px;
+  }
+}
+
+@media screen and (max-width: 400px),
+       screen and (max-height: 250px) {
+  td {
+    border: 2px solid black;
+  }
+  th {
+    font-size: 12px;
+    height: 17px;
+  }
+}
+
+.name .subtitle {
+    font-size: 75%;
+}
+/* don't want this here for stream 
+}
+.name .carname {
+  font-size: 75%;								 
+    font-style: italic;
+}
+*/
+
+#overlay_background {
+    position: fixed;
+    z-index:100;
+    top: 0px;
+    left: 0px;
+    height:100%;
+    width:100%;
+    background: #000;
+    display: none;
+}
+
+.overlay_foreground {
+  display: none;
+  width: 512px;
+  padding: 15px 20px;
+  background-color: transparent;
+/*  -webkit-border-radius: 6px;
+  -moz-border-radius: 6px;
+  border-radius: 6px;
+  -webkit-box-shadow: 0 1px 5px rgba(0, 0, 0, 0.5);
+  -moz-box-shadow: 0 1px 5px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.5); */
+}
+
+#timer_overlay {
+  color: #a7101c;
+  font-size: 50px;
+  font-weight: bold;
+  text-align: center;
+}
+
+#timer_overlay p {
+  background: white;
+  opacity: 0.75;
+}
+
+.banner_version { display: none; }
+
+.aside { display: none; }

--- a/website/js/now-racing-OBS.js
+++ b/website/js/now-racing-OBS.js
@@ -1,0 +1,437 @@
+
+																			  
+		  
+						  
+								
+																					 
+																		
+							
+				  
+									 
+															 
+								  
+					 
+							 
+								   
+   
+ 
+																		  
+// The base version of this js file is from 2022 version of Derby Net. 
+// It has not been updated to reflect the latest js functionality
+
+var Lineup = {
+  // heat and roundid identify the lineup currently displayed.  They're also
+  // sent in the polling query to tell the server what lineup we'd want results
+  // for.
+  roundid: 0,
+  heat: 0,
+  // Normally we just acquire more heat results for the current heat, as they're
+  // reported by the timer.  If the number of <heat-result> elements decreases
+  // for a heat, we need to clear out the old values by treating the update like
+  // it's a new heat.  previous_heat_results tracks how many <heat-result>
+  // elements were in the previous update.
+  previous_heat_results: 0,
+
+  // While hidden by a replay, don't advance the display.
+  holding: false,
+  hold: function() {
+    this.holding_display = true;
+  },
+  release: function() {
+    this.holding = false;
+  },
+
+  // display_lingers_until tells when it's OK to advance the display to the next
+  // heat.  Value is a timestamp in milliseconds.
+  display_lingers_until: 0,
+
+  // After an animation of heat results, hold the display for a few seconds
+  // before advancing to the next heat.
+  start_display_linger: function() {
+    this.display_lingers_until = Date.now() + g_linger_ms;
+  },
+
+  ok_to_change: function() {
+    return !this.holding && Date.now() > this.display_lingers_until;
+  },
+
+  // When the current heat differs from what we're presently displaying,
+  // we get a <current-heat/> element, plus some number of <racer>
+  // elements identifying the new heat's contestants.
+  process_new_lineup: function(data, row_height) {
+    var current = data["current-heat"];
+    if (data.hasOwnProperty('timer-trouble')) {
+      Overlay.show('#timer_overlay');
+    } else if (!current["now_racing"] && this.ok_to_change()) {
+      Overlay.show('#paused_overlay');
+    } else {
+      Overlay.clear();
+    }
+
+    if (data.hasOwnProperty('timer-test')) {
+      // In timer-test mode, we hide several columns (marked .no-test) and add
+      // in their place a single-cell .test-only column showing the
+      // "timer-testing" image.  When not in timer-test mode, undo all of that.
+      if ($('td.test-only').length == 0) {
+        $(".no-test").addClass('hidden');
+        $("tr#table-headers th").first().after("<th class='test-only'/>");
+        $("tr[data-lane=1] td.lane").after("<td class='test-only' rowspan='" + $("td.lane").length + "'>"
+                                           + "<img src='img/timer-testing.png'/><br/>"
+                                           + "Timer testing"
+                                           + "</td>");
+      }
+    } else {
+      if ($('td.test-only').length > 0) {
+        $(".test-only").remove();
+        $(".no-test").removeClass("hidden");
+      }
+    }
+    // We always need to notice an increase in the number of heat-results, in
+    // case they get cleared before the ok_to_change() test lets us update the
+    // screen.
+    var new_heat_results =
+        data.hasOwnProperty('heat-results') ? data["heat-results"].length : 0;
+    if (new_heat_results > this.previous_heat_results) {
+      this.previous_heat_results = new_heat_results;
+    }
+
+    if (this.ok_to_change()) {
+      var new_roundid = current.roundid;
+      var new_heat = current.heat;
+      var is_new_heat = new_roundid != this.roundid || new_heat != this.heat
+          || new_heat_results < this.previous_heat_results;
+      this.roundid = new_roundid;
+      this.heat = new_heat;
+      this.previous_heat_results = new_heat_results;
+
+      var nheats = current['number-of-heats'];
+//orig begin
+     if (nheats) {
+        var round_class_name = current['class'];
+        $('.banner_title').text((round_class_name ? round_class_name + ', ' : '')
+                                + 'Heat ' + this.heat + ' of ' + nheats);
+      }
+//orig end
+
+
+      var racers = data.racers;
+      var zero = data.precision == 4 ? '0.0000' : '0.000';
+
+      if (is_new_heat && racers.length > 0) {
+        FlyerAnimation.enable_flyers();
+        FlyerAnimation.set_number_of_racers(racers.length);
+
+        //FontAdjuster.reset(); keeps font consistent for stream
+        // Clear old results
+        $('[data-lane] .carnumber').text('');
+        $('[data-lane] .photo').empty();
+        $('[data-lane] .name').text('');
+        $('[data-lane] .time').css({opacity: 0}).text(zero);
+        $('[data-lane] .speed').css({opacity: 0}).text('200.0');
+        $('[data-lane] .place span').text('');
+        $('[data-lane] .photo img').remove();
+        for (var i = 0; i < racers.length; ++i) {
+          var r = racers[i];
+          var lane = r.lane;
+          $('[data-lane="' + lane + '"] .lane').text(lane);
+          $('[data-lane="' + lane + '"] .name').html('<div></div>');
+          $('[data-lane="' + lane + '"] .name div').text(r.name);
+          if (r.hasOwnProperty('photo') && r.photo != '') {
+            $('[data-lane="' + lane + '"] .photo').html(
+              $('<img/>')
+                .attr('src', r.photo)
+                .css('max-height', row_height)
+            );
+          }
+
+          if (r.hasOwnProperty('carname') && r.carname != '') {
+            $('[data-lane="' + lane + '"] .carnombre').append(' <span id="carname-' + lane + '" class="subtitle"/>');
+            $('#carname-' + lane).text(r.carname);
+          }
+          if (r.hasOwnProperty('subgroup')) {
+            $('[data-lane="' + lane + '"] .name').append(' <span id="subgroup-' + lane + '" class="subtitle"/>');
+            $('#subgroup-' + lane).text(r.subgroup);
+          }
+
+          $('[data-lane="' + lane + '"] .carnumber').text(r.carnumber);
+        }
+      } else if (racers.length > 0) {
+
+        // Same heat, but possibly updated photo paths
+        for (var i = 0; i < racers.length; ++i) {
+          var r = racers[i];
+          var lane = r.lane;
+          if (r.hasOwnProperty('photo') && r.photo != '') {
+            if ($('[data-lane="' + lane + '"] .photo img').length == 0) {
+              // A window resize, below, may have removed the <img/> element on an interim basis
+              $('[data-lane="' + lane + '"] .photo').html(
+                $('<img/>')
+                  .attr('src', r.photo)
+                  .css('max-height', row_height)
+              );
+            }
+            if (r.photo != $('[data-lane="' + lane + '"] .photo img').attr('src')) {
+              $('[data-lane="' + lane + '"] .photo img').attr('src', r.photo);
+            }
+          } else {
+            $('[data-lane="' + lane + '"] .photo').empty();
+          }
+        }
+      }
+    }
+
+    // NOTE Any failure to get here will cause the page to get stuck.
+    Poller.queue_next_request(this.roundid, this.heat);
+  }
+};
+
+
+var FlyerAnimation = {
+  ok_to_animate: true,
+
+  enable_flyers: function() {
+    this.ok_to_animate = true;
+  },
+
+  // Once the animation has started, avoid starting again until explicitly
+  // re-enabled with a new heat or a request to repeat the animation.
+  flyers_started: function() {
+    this.ok_to_animate = false;
+  },
+
+  // If we get an incomplete update (that is, some but not all heat results from
+  // the current heat were written to the database at the moment the <heat-result>
+  // elements got generated), then we may be missing some of the possible places:
+  // we might have 1st and 3rd place, but not 2nd and 4th.
+  //
+  // It's the holes in the place_to_lane mapping that screws us: we only attempt
+  // to stop the animation when we go beyond place_to_lane.length; otherwise, we
+  // assume we can find a place_to_lane entry for 2nd place if place_to_lane is
+  // big enough to account for 3rd place.
+  //
+  // The test for a complete set of heat-results is that we have as many
+  // heat-results as lanes.
+  number_of_racers: 0,
+  set_number_of_racers: function(n) {
+    this.number_of_racers = n;
+  },
+
+  should_animate: function(nresults) {
+    return this.ok_to_animate && nresults >= this.number_of_racers;
+  },
+
+  // Javascript passes arrays (like place_to_lane) by reference, so no
+  // worries about doing a lot of copying in this recursion.
+  //
+  // This is implemented recursively because we use the completion
+  // callback for animate to advance to the next flyer.
+  //
+  // The animate_flyers function doesn't really benefit from being in an
+  // object -- it passes around all the state it needs.
+  animate_flyers: function(place, place_to_lane, completed) {
+    if (place >= place_to_lane.length) {
+      $('.place').css({opacity: 100});
+      $('.flying').animate({opacity: 0}, 1000);
+      completed();
+    } else {
+      var flyer = $('#place' + place);
+      var target = $('[data-lane="' + place_to_lane[place] + '"] .place');
+      if (target.length > 0) {
+        var border = parseInt(target.css('border-top-width'));
+        // Apparently WebKit and Gecko (at least) model collapsed table
+        // borders borders differently; in particular, target.offset() is
+        // affected; we need to compensate by changing the border
+        // adjustment.  Knowing that the CSS specifies 14px borders for this
+        // table, we use the reported border width to distinguish between
+        // the two engines.
+        if (border < 14) {
+          border = 0;
+        }
+        var span =  $('[data-lane="' + place_to_lane[place] + '"] .place span');
+        var font_size = span.css('font-size');
+        flyer.css({left: -target.outerWidth(),
+                   width: target.outerWidth(),
+                   top: target.offset().top - border,
+                   height: target.outerHeight(),
+                   fontSize: font_size, // as a string, e.g., 85px
+                   padding: 0,
+                   opacity: 100});
+        flyer.animate({left: target.offset().left - border},
+                      300,
+                      function() {
+                        FlyerAnimation.animate_flyers(place + 1, place_to_lane, completed);
+                      });
+      } else {
+        console.log("Couldn't find an entry for " + place + "-th place.");
+        FlyerAnimation.animate_flyers(place + 1, place_to_lane, completed);
+      }
+    }
+  }
+};
+
+var Poller = {
+  // Timestamp when the last polling request was sent; used by watchdog to
+  // detect a failure to queue a new request.
+  time_of_last_request: 0,
+
+  // Records the identifier of the timeout that will send the next polling
+  // request, or 0 if no request is queued.
+  id_of_timeout: 0,
+
+  // If we're being shown within a replay iframe, suspend polling while a replay
+  // is showing and we're not visible; resume when we have the display again.
+  suspended: false,
+
+  // Queues the next poll request when processing of the current request has
+  // completed, including animations, if any.  Because animations are handled
+  // asynchronously, with completion callbacks, we can't just start the next
+  // request when process_now_racing_element returns.
+  queue_next_request: function(roundid, heat) {
+    if (this.id_of_timeout != 0) {
+      console.log("Trying to queue a polling request when there's already one pending; ignored.");
+    } else {
+      Poller.id_of_timeout = setTimeout(function() {
+        Poller.id_of_timeout = 0;
+        Poller.poll_for_update(roundid, heat);
+      }, 500);  // 0.5 sec
+    }
+  },
+
+  poll_for_update: function(roundid, heat) {
+    if (typeof(simulated_poll_for_update) == "function") {
+      simulated_poll_for_update();
+    } else if (this.suspended) {
+      Poller.queue_next_request(roundid, heat);
+    } else {
+      // TODO It shouldn't be necessary to send row-height to the server;
+      // instead just construct a racer photo URL from the returned racerid.
+      var row_height = 0;
+      var photo_cells = $('td.photo');
+      var border = parseInt(photo_cells.css('border-bottom-width'));
+
+      if (photo_cells.length > 0) {
+        // Position of the first td.photo may get adjusted
+        row_height = Math.floor(($(window).height() - photo_cells.position().top) / photo_cells.length) - border;
+      }
+
+      this.time_of_last_request = Date.now();
+      $.ajax('action.php',
+             {type: 'GET',
+              data: {query: 'poll',
+                     values: 'current-heat,heat-results,precision,racers,timer-trouble',
+                     roundid: roundid,
+                     heat: heat,
+                     'row-height': row_height},
+              success: function(data) {
+                process_polling_result(data, row_height);
+              },
+              error: function() {
+                Poller.queue_next_request(roundid, heat);
+              }
+             });
+    }
+  },
+
+  // Correct operation depends on queuing a new request when we're done
+  // processing the last one, including any animations (could take a few
+  // seconds).  As a safeguard against a bug that perhaps prevents queuing the
+  // next request, the watchdog periodically tests whether one seems overdue,
+  // and may queue a new request if so.
+  watchdog: function() {
+    if (this.id_of_timeout != 0 && this.time_of_last_request + 15000 < Date.now()) {
+      console.error("Watchdog notices no requests lately, and none queued!");
+      this.queue_next_request();
+    }
+  }
+};
+
+// Walks through each of the heat-result {lane= time= place= speed=} elements,
+// in order, building a mapping from the reported place to the matching lane.
+//
+function process_polling_result(data, row_height) {
+  var precision = data.hasOwnProperty('precision') ? data.precision : 3;
+  var heat_results = data["heat-results"];
+  if (heat_results && heat_results.length > 0) {
+    var place_to_lane = new Array();  // place => lane
+    for (var i = 0; i < heat_results.length; ++i) {
+      var hr = heat_results[i];
+      var lane = hr.lane;
+      var place = hr.place;
+      place_to_lane[parseInt(place)] = lane;
+
+      $('[data-lane="' + lane + '"] .time')
+        .css({opacity: 100})
+        .text(Number.parseFloat(hr.time).toFixed(precision) + ' s');
+      if (FlyerAnimation.ok_to_animate) {
+        $('[data-lane="' + lane + '"] .place').css({opacity: 0});
+      }
+      $('[data-lane="' + lane + '"] .place span').text(place);
+      if (hr.speed != '') {
+        $('[data-lane="' + lane + '"] .speed')
+          .css({opacity: 100})
+          .text(hr.speed+' mph');
+      }
+    }
+
+    if (FlyerAnimation.should_animate(heat_results.length)) {
+      FlyerAnimation.flyers_started();
+      FlyerAnimation.animate_flyers(1, place_to_lane, function () {
+        // Need to continue to poll for repeat-animation, just not
+        // accept new participants for 10 seconds.
+        Lineup.start_display_linger();
+        Lineup.process_new_lineup(data, row_height);
+      });
+    } else {
+      Lineup.process_new_lineup(data, row_height);
+    }
+  } else {
+    Lineup.process_new_lineup(data, row_height);
+  }
+}
+
+// Update the table height to fill the window below the title bar, then adjust
+// the margin on the "flyer" elements.  The flyer height and width will be set
+// when the animation actually runs.
+function resize_table() {
+  // Since images have a fixed size, they can cause the table to be too tall for
+  // the new window size.  We temporarily remove the photos and rely on
+  // process_new_heat, above, to repopulate with different-sized photos.
+  $("table td.photo").empty();
+  $("table").css({height: $(window).height() - 60});
+
+  var place = $('[data-lane="1"] .place');
+  var btop = parseInt(place.css('border-top'));
+  var mtop = parseInt(place.css('margin-top'));
+  $('.flying').css({margin: mtop + btop});
+
+  //FontAdjuster.table_resized();
+}
+
+// This function receives messages from the surrounding replay kiosk, if there
+// is one.
+function on_message(msg) {
+  if (msg == 'replay-started') {
+    // TODO There's a race here: if the flyers have already started when replay takes
+    // over the screen, the audience may not get to see the whole thing.
+    Poller.suspended = true;
+    Lineup.hold();
+  } else if (msg == 'replay-ended') {
+    // Start the timer that blocks advancing to the next heat
+    Lineup.start_display_linger();
+    Lineup.release();
+    Poller.suspended = false;
+    FlyerAnimation.enable_flyers();
+  }
+}
+
+$(function () {
+  resize_table();
+  $(window).resize(function() { resize_table(); });
+
+  window.onmessage = function(e) { on_message(e.data); };
+
+  // This 1-second delay is to let the initial resizing take effect
+  setTimeout(function() { Poller.poll_for_update(0, 0); }, 1000);
+  // Run the watchdog every couple seconds
+  setInterval(function() { Poller.watchdog(); }, 2000);
+});

--- a/website/kiosks/now-racing-obs.kiosk
+++ b/website/kiosks/now-racing-obs.kiosk
@@ -1,0 +1,103 @@
+<?php @session_start();
+$nlanes = get_lane_count();
+$use_points = read_raceinfo_boolean('use-points');
+$linger_ms = read_raceinfo('now-racing-linger-ms', 10000);
+require_once('inc/banner.inc');
+?><!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+<title>Pack 785 OBS Layout Hack</title>
+<link rel="stylesheet" type="text/css" href="css/jquery-ui.min.css"/>
+<link rel="stylesheet" type="text/css" href="css/global.css"/>
+<link rel="stylesheet" type="text/css" href="css/kiosks.css"/>
+<link rel="stylesheet" type="text/css" href="css/now-racing-obs.css"/>
+<script type="text/javascript" src="js/jquery.js"></script>
+<script type="text/javascript" src="js/jquery-ui.min.js"></script>
+<?php require('inc/kiosk-poller.inc'); ?>
+<script type="text/javascript" src="js/now-racing-overlay.js"></script>
+<script type="text/javascript" src="js/now-racing-OBS.js"></script>
+<script type="text/javascript" src="js/now-racing-adjust-fonts.js"></script>
+<?php if (@$simulated_polling_url) { ?>
+<script type="text/javascript" src="<?php echo @$simulated_polling_url; ?>"></script>
+<?php } ?>
+<?php // If $nlanes not yet set, then this page isn't ready for display.
+    if ($nlanes <= 0) {
+?><script type="text/javascript">
+$(function () {
+    setTimeout(function() {
+        console.log("Reloading because nlanes not set yet.");
+        location.reload(true);
+      },
+      5000);
+  });
+</script>
+<?php }  // if ($nlanes <= 0)
+?>
+<script type="text/javascript">
+var g_linger_ms = <?php echo $linger_ms; ?>;
+</script>
+</head>
+<body>
+<?php make_banner('Racing', /* back_button */ false); ?>
+<?php if ($nlanes > 0) { ?>
+<table id="main-table">
+
+<!--This part is edited to work with the OBS overlay. Tables are set to fixed
+# This edit sets a fixed table, cell, + font sizes to be shown in a 1920x1080 
+# web browser in OBS. Call this page using the link
+# http://<localhost>/kiosk.php?page=kiosks/now-racing-obs.kiosk
+-->
+<tr id="table-headers">
+    <th style="width: 80px;">Lane</th>
+    <th class='carnumber no-test' style="width: 120px;">Car</th>
+    <th class='no-test' style="width: 40%;">Racer</th>
+    <th class='no-test' style="width: 60%;">Carname</th>
+    <th style="width: 80px;">Place</th>
+<?php if (!$use_points) { ?>
+    <th style="width: 120px;">Time</th>
+    <th class='no-test' style="width: 120px;"><div id="speed-div">Speed <span class="aside">(scale MPH)</span></div></th>
+<?php } ?>
+</tr>
+
+<?php
+for ($i = 1; $i <= $nlanes; ++$i) {
+      echo '<tr data-lane="'.$i.'">'
+          .'<td class="lane" style="width: 80px; font-size: 48px;">'.$i.'</td>'
+          .'<td class="carnumber no-test" style="width: 80px; font-size: 48px;"></td>'
+          .'<td class="name no-test" style="width: 200px; font-size: 48px;"></td>'
+          .'<td class="carnombre no-test" style="width: 800px; font-size: 48px;"></td>'
+          .'<td class="place" style="width: 80px; font-size: 36px;"><span class="sp"/></td>';
+      if (!$use_points) {
+        echo '<td class="time" style="width: 80px; font-size: 20px;"></td>'
+            .'<td class="speed no-test" style="width: 80px; font-size: 20px;"></td>';
+      }
+      echo '</tr>'."\n";
+  }
+?>
+<!--end pack 785 edit-->
+
+</table>
+<?php
+  for ($i = 1; $i <= $nlanes; ++$i) {
+      echo '<div id="place'.$i.'" class="flying"><span>'.$i.'</span></div>'."\n";
+  }
+?>
+<?php } else { ?>
+<h2>Number of lanes not yet recorded...</h2>
+<?php } ?>
+
+<!--We don't want this showing up in the stream
+<//?php require_once('inc/ajax-failure.inc'); ?>
+
+<div id="overlay_background"></div>
+<div id="paused_overlay" class="overlay_foreground">
+ <img src="img/pause.png"/>
+</div>
+<div id="timer_overlay" class="overlay_foreground">
+ <img src="img/timer-red.png"/>
+ <p>Check timer.</p>
+</div>
+-->
+</body>
+</html>


### PR DESCRIPTION
These changes create a new kiosk aimed specifically at creating a consistent layout for displaying race results in the OBS Layout made for the Pack 785 Live Stream.  Specifically the following is done: -now-racing-obs.kiosk removes + changes the parameters called and displayed. Removes the timer and ajax error overlays. Calls OBS layout specific css and js files. -now-racing-obs.css adds consistent sizing for fonts and cell spacing -now-racing-OBS.js removes the call to update font sizes and readjust the cell widths to react to display size.

The layout is optimized for a 1920x1080 browser page.